### PR TITLE
Fix build error in utils.go

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -76,7 +76,7 @@ type Router struct {
 }
 
 func NewRouter() Router {
-	return Router{Object: js.Global.Get("Router").New()}
+	return Router{Object: *js.Global.Get("Router").New()}
 }
 func (r Router) On(path string, handler func(string)) {
 	r.Call("on", path, handler)


### PR DESCRIPTION
Fix the build error: `utils.go:79: cannot use js.Global.Get("Router").New() (type *js.Object) as type js.Object in field value`.

Dereference new `*js.Object` to allow assignment to Router.Object field.